### PR TITLE
Create settings page before

### DIFF
--- a/src/org/ciscavate/cjwizard/WizardContainer.java
+++ b/src/org/ciscavate/cjwizard/WizardContainer.java
@@ -287,8 +287,11 @@ public class WizardContainer extends JPanel implements WizardController {
       }
 
       _visitedPath.push(removing);
-      // update roll-back the settings:
+
+      // Save settings (so can be restored if we return to the same page).
       removing.updateSettings(getSettings());
+      getSettings().commit();
+      // But don't let it as actual settings.
       getSettings().rollBack();
 
       // Save current buttons statuses.

--- a/src/org/ciscavate/cjwizard/WizardContainer.java
+++ b/src/org/ciscavate/cjwizard/WizardContainer.java
@@ -329,7 +329,6 @@ public class WizardContainer extends JPanel implements WizardController {
          }
 
          // get the settings from the page that is going away:
-         getSettings().newPage(lastPage.getId());
          lastPage.updateSettings(getSettings());
 
          // Save the current buttons status
@@ -382,6 +381,9 @@ public class WizardContainer extends JPanel implements WizardController {
 
       _path.add(nextPage);
 
+      // And add a page for its settings.
+      getSettings().newPage(nextPage.getId());
+
       // tell the page that it is about to be rendered:
       nextPage.rendering(getPath(), getSettings());
       _template.setPage(nextPage);
@@ -404,9 +406,6 @@ public class WizardContainer extends JPanel implements WizardController {
       if (-1 == idx) {
          // new page
          if (null != lastPage) {
-            // get the settings from the page that is going away:
-            getSettings().newPage(lastPage.getId());
-            
             // Save the current statuses
             _cancelStatuses.push(_cancelAction.isEnabled());
             _prevStatuses.push(_prevAction.isEnabled());
@@ -457,6 +456,9 @@ public class WizardContainer extends JPanel implements WizardController {
             
             getPath().add(page);
          }
+
+         // And we prepare the page of settings for the new page.
+         getSettings().newPage(page.getId());
 
       } else {
          // page is in the path at idx.


### PR DESCRIPTION
We need to create the settings page before the new page is used instead of doing it when it will go out. Because if you do in the other way, it can lose configured settings when going back.

For example, if you go to step 2 and type a long form and make you think about something you forgot in the previous step, you go back correct the step 1 information and when go next to step 2 you have lost all your work.

I think is better to create the page before the page is displayed so we can save its settings when going back and restore them when we return to the page.